### PR TITLE
ListAllFiles function

### DIFF
--- a/list.go
+++ b/list.go
@@ -1,0 +1,31 @@
+package ctxvfs
+
+import "context"
+
+// ListAllFileser is type that implements ListAllFiles
+type ListAllFileser interface {
+	// ListAllFiles returns a slice of all file paths on a VFS. This is
+	// only files (excludes directories). This interface exists for
+	// implementors to provide a faster way to list all files than walking
+	// the file tree with ReadDir/etc.
+	ListAllFiles(ctx context.Context) ([]string, error)
+}
+
+// ListAllFiles returns a slice of all file paths (excludes directories).
+func ListAllFiles(ctx context.Context, fs FileSystem) ([]string, error) {
+	if l, ok := fs.(ListAllFileser); ok {
+		return l.ListAllFiles(ctx)
+	}
+	var filenames []string
+	w := Walk(ctx, "/", fs)
+	for w.Step() {
+		if err := w.Err(); err != nil {
+			return nil, err
+		}
+		fi := w.Stat()
+		if fi.Mode().IsRegular() {
+			filenames = append(filenames, w.Path())
+		}
+	}
+	return filenames, nil
+}

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,32 @@
+package ctxvfs
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestListAllFiles(t *testing.T) {
+	want := []string{
+		"/foo/bar.txt",
+		"/foo/bar/three.txt",
+		"/other-top.txt",
+		"/top.txt",
+	}
+	m := map[string][]byte{}
+	for _, p := range want {
+		m[p[1:]] = []byte("a")
+	}
+	fs := Map(m)
+
+	got, err := ListAllFiles(context.Background(), fs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got != want\ngot:  %v\nwant: %v", got, want)
+	}
+}


### PR DESCRIPTION
We use this in production at Sourcegraph to speed up operations for remote VFSs.
(Allows us to avoid latency of Stat)