### PR TITLE
Windows support

### DIFF
--- a/map.go
+++ b/map.go
@@ -54,8 +54,8 @@ func (fs mapFS) Open(ctx context.Context, p string) (ReadSeekCloser, error) {
 }
 
 func (fs mapFS) Lstat(ctx context.Context, p string) (os.FileInfo, error) {
-	if p == "/" {
-		return dirInfo("/"), nil
+	if p == "/" || p == "" {
+		return dirInfo(p), nil
 	}
 	p = filename(p)
 	b, ok := fs[p]
@@ -88,7 +88,7 @@ func (fs mapFS) Stat(ctx context.Context, p string) (os.FileInfo, error) {
 // with a slash to be in the root.
 func slashdir(p string) string {
 	d := path.Dir(p)
-	if d == "." || d == "/" {
+	if d == "." || d == "/" || d == "" {
 		return "/"
 	}
 	if strings.HasPrefix(p, "/") {
@@ -98,10 +98,11 @@ func slashdir(p string) string {
 }
 
 func (fs mapFS) ReadDir(ctx context.Context, p string) ([]os.FileInfo, error) {
-	p = path.Clean(p)
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
+	p = cleanPath(p)
+	if p == "" {
+		p = "/"
 	}
+
 	var ents []string
 	fim := make(map[string]os.FileInfo) // base -> fi
 	for fn, b := range fs {

--- a/os.go
+++ b/os.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	pathpkg "path"
-	"path/filepath"
 )
 
 // OS returns an implementation of FileSystem reading from the
@@ -29,18 +27,13 @@ type osFS string
 
 func (root osFS) String() string { return "os(" + string(root) + ")" }
 
-func (root osFS) resolve(path string) string {
-	// Clean the path so that it cannot possibly begin with ../.
-	// If it did, the result of filepath.Join would be outside the
-	// tree rooted at root.  We probably won't ever see a path
-	// with .. in it, but be safe anyway.
-	path = pathpkg.Clean("/" + path)
-
-	return filepath.Join(string(root), path)
-}
-
 func (root osFS) Open(ctx context.Context, path string) (ReadSeekCloser, error) {
-	f, err := os.Open(root.resolve(path))
+	resolved, err := root.resolve(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -57,13 +50,25 @@ func (root osFS) Open(ctx context.Context, path string) (ReadSeekCloser, error) 
 }
 
 func (root osFS) Lstat(ctx context.Context, path string) (os.FileInfo, error) {
-	return os.Lstat(root.resolve(path))
+	resolved, err := root.resolve(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.Lstat(resolved)
 }
 
 func (root osFS) Stat(ctx context.Context, path string) (os.FileInfo, error) {
-	return os.Stat(root.resolve(path))
+	resolved, err := root.resolve(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(resolved)
 }
 
 func (root osFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(root.resolve(path)) // is sorted
+	resolved, err := root.resolve(path)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadDir(resolved) // is sorted
 }

--- a/os_other.go
+++ b/os_other.go
@@ -1,0 +1,20 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package ctxvfs
+
+import (
+	pathpkg "path"
+	"path/filepath"
+)
+
+func (root osFS) resolve(path string) (string, error) {
+	// Clean the path so that it cannot possibly begin with ../.
+	// If it did, the result of filepath.Join would be outside the
+	// tree rooted at root.  We probably won't ever see a path
+	// with .. in it, but be safe anyway.
+	return filepath.Join(string(root), pathpkg.Clean("/" + path))
+}

--- a/os_test.go
+++ b/os_test.go
@@ -1,0 +1,80 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ctxvfs_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/tools/godoc/vfs"
+	"golang.org/x/tools/godoc/vfs/mapfs"
+)
+
+func TestOpen(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmpDir, "foo")
+	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := vfs.NameSpace{}
+	fs.Bind("/", vfs.OS("/"), "/", vfs.BindAfter)
+
+	_, err = fs.Open(file)
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	fs = vfs.NameSpace{}
+	fs.Bind("/", vfs.OS(tmpDir), "/", vfs.BindAfter)
+
+	_, err = fs.Open("foo")
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	_, err = fs.Open("/foo")
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+
+}
+
+func TestOpenOverlay(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmpDir, "foo")
+	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs := mapfs.New(map[string]string{file: "c"})
+	fs := vfs.NameSpace{}
+	fs.Bind("/", mfs, "/", vfs.BindBefore)
+	fs.Bind("/", vfs.OS("/"), "/", vfs.BindAfter)
+
+	_, err = fs.Open(file)
+	if err != nil {
+		t.Errorf("Cannot read overlayed file (%s)", err)
+	}
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package ctxvfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var errInvalidPath = errors.New("Cannot resolve absolute path")
+
+func (root osFS) resolve(path string) (string, error) {
+	// Clean the path so that it cannot possibly begin with ../.
+	// If it did, the result of filepath.Join would be outside the
+	// tree rooted at root.  We probably won't ever see a path
+	// with .. in it, but be safe anyway.
+	path = strings.TrimLeft(filepath.Clean(filepath.Join(string(root), path)), string(os.PathSeparator))
+	if !filepath.IsAbs(path) {
+		return "", errInvalidPath
+	}
+	return path, nil
+}


### PR DESCRIPTION
Purpose of this commit is to add Windows support where path building rules differ from Unix one and there is no common root (/). To achieve Windows support I propose the following:
- enable binding to "" mount point because binding to "/" does not make sense on Windows
- using platform-specific functions to clean paths if they are absolute instead of producing pseudo-absolute paths by prefixing them with slash
- some refactoring to use the same path cleaner everywhere

My final goal is to make go-langserver work with Visual Studio Code on Windows.

Also, I think there was a bug in `Open()` with multiple matching namespaces  - we should not stop resolving namespace when first one found.