### PR TITLE
Support for OS("")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: go
+
 go: 
  - 1.7.1
  - tip
+
+go_import_path: github.com/sourcegraph/ctxvfs
 
 script:
  - go test -race -v ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{build}"
+shallow_clone: true
+clone_folder: c:\gopath\src\github.com\sourcegraph\ctxvfs
+
+environment:
+  GOPATH: c:\gopath
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - go version
+  - go env
+  - go get -d -t ./...
+  - go test -i ./...
+
+build_script:
+  - go test -race -v ./...

--- a/os_other.go
+++ b/os_other.go
@@ -1,0 +1,20 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package ctxvfs
+
+import (
+	pathpkg "path"
+	"path/filepath"
+)
+
+func (root osFS) resolve(path string) (string, error) {
+	// Clean the path so that it cannot possibly begin with ../.
+	// If it did, the result of filepath.Join would be outside the
+	// tree rooted at root.  We probably won't ever see a path
+	// with .. in it, but be safe anyway.
+	return filepath.Join(string(root), pathpkg.Clean("/"+path)), nil
+}

--- a/os_test.go
+++ b/os_test.go
@@ -1,0 +1,101 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ctxvfs
+
+import (
+	"io/ioutil"
+	"strings"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenLocal(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmpDir, "foo")
+	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := NameSpace{}
+	fs.Bind("/", OS("/"), "/", BindAfter)
+
+	_, err = fs.Open(nil, file)
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	fs = NameSpace{}
+	fs.Bind("/", OS(tmpDir), "/", BindAfter)
+
+	_, err = fs.Open(nil, "foo")
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	_, err = fs.Open(nil, "/foo")
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	fs = NameSpace{}
+	fs.Bind("", OS(""), "", BindAfter)
+
+	_, err = fs.Open(nil, file)
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+
+	_, err = fs.Open(nil, "/"+file)
+	if err != nil {
+		t.Errorf("Cannot read local file (%s)", err)
+	}
+}
+
+func TestOpenOverlay(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(tmpDir, "foo")
+	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	mapfs := Map(map[string][]byte{
+		strings.TrimPrefix(file, "/"): []byte("qux"),
+	})
+
+	fs := NameSpace{}
+	fs.Bind("", mapfs, "", BindBefore)
+	fs.Bind("", OS(""), "", BindAfter)
+
+	stream, err := fs.Open(nil, file)
+	if err != nil {
+		t.Errorf("Cannot read overlayed file (%s)", err)
+	}
+	content, err := ioutil.ReadAll(stream)
+	if err != nil {
+		t.Errorf("Cannot read overlayed file (%s)", err)
+	}
+
+	if string(content) != "qux" {
+		t.Errorf("Cannot read overlayed file, expected `qux`, got `%s`", content)
+	}
+
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package ctxvfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var errInvalidPath = errors.New("Cannot resolve absolute path")
+
+func (root osFS) resolve(path string) (string, error) {
+	// Clean the path so that it cannot possibly begin with ../.
+	// If it did, the result of filepath.Join would be outside the
+	// tree rooted at root.  We probably won't ever see a path
+	// with .. in it, but be safe anyway.
+	path = strings.TrimPrefix(filepath.Clean(filepath.Join(string(root), path)), string(os.PathSeparator))
+	if !filepath.IsAbs(path) {
+		return "", errInvalidPath
+	}
+	return path, nil
+}

--- a/os_windows_test.go
+++ b/os_windows_test.go
@@ -3,118 +3,80 @@
 package ctxvfs
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
 func TestWindowsMount(t *testing.T) {
 
-	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-	if err = os.MkdirAll(tmpDir, 0700); err != nil {
-		t.Fatal(err)
-	}
-	tmpFile := filepath.Join(tmpDir, "foo")
-	if err = ioutil.WriteFile(tmpFile, []byte("bar"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	fStat, _ := os.Stat(tmpFile)
-
-	tmpFile = filepath.ToSlash(tmpFile)
-	tmpDir = filepath.ToSlash(tmpDir)
-
-	volname := filepath.VolumeName(tmpFile)
-
-	var (
-		empty       = ""           // - empty root, OS("")
-		volume      = volname      // - volume name, OS("C:")
-		slashvolume = "/" + volume // - volume name prefixed with slash, OS("/C:")
-		dir         = tmpDir       // - directory, OS("C:/foo/bar")
-		dirslash    = tmpDir + "/" // - directory followed by slash, OS("C:/foo/bar/")
-		slashdir    = "/" + tmpDir // - directory prefixed with slash, OS("/C:/foo/bar")
-	)
-
-	var (
-		file           = tmpFile                             // absolute file path, C:/foo/bar
-		slashfile      = "/" + tmpFile                       // absolute file path prefixed with slash, /C:/foo/bar
-		relfile        = strings.TrimPrefix(tmpFile, volume) // path w/o volume name, /foo/bar
-		shortfile      = "foo"                               // relative path, foo
-		slashshortfile = "/foo"                              // relative path prefixed with slash, /foo
-	)
-
 	// keys are mount points,
-	// values indicate if OS.Stat(path) should succeed for a given path
-	tests := map[string]map[string]bool{
-		empty: {
-			file:           true,
-			slashfile:      true,
-			relfile:        false,
-			shortfile:      false,
-			slashshortfile: false,
+	// values contain expected results for osFS.resolve(key)
+	tests := map[string]map[string]string{
+		"": {
+			"C:/folder/file":  "C:\\folder\\file",
+			"D:/folder/file":  "D:\\folder\\file",
+			"/C:/folder/file": "C:\\folder\\file",
+			"/folder/file":    "",
+			"file":            "",
+			"/file":           "",
 		},
-		volume: {
-			file:           false,
-			slashfile:      false,
-			relfile:        true,
-			shortfile:      false,
-			slashshortfile: false,
+		"C:": {
+			"C:/folder/file":  "C:\\folder\\file",
+			"/C:/folder/file": "C:\\folder\\file",
+			"/folder/file":    "C:\\folder\\file",
+			"file":            "C:\\file",
+			"/file":           "C:\\file",
+			"D:/folder/file":  "",
 		},
-		slashvolume: {
-			file:           false,
-			slashfile:      false,
-			relfile:        true,
-			shortfile:      false,
-			slashshortfile: false,
+		"/C:": {
+			"C:/folder/file":  "C:\\folder\\file",
+			"/C:/folder/file": "C:\\folder\\file",
+			"/folder/file":    "C:\\folder\\file",
+			"file":            "C:\\file",
+			"/file":           "C:\\file",
+			"D:/folder/file":  "",
 		},
-		dir: {
-			file:           false,
-			slashfile:      false,
-			relfile:        false,
-			shortfile:      true,
-			slashshortfile: true,
+		"C:/folder": {
+			"C:/folder/file":           "C:\\folder\\file",
+			"/C:/folder/file":          "C:\\folder\\file",
+			"/folder/file":             "C:\\folder\\folder\\file",
+			"file":                     "C:\\folder\\file",
+			"/file":                    "C:\\folder\\file",
+			"C:/anoherfolder/file":     "",
+			"C:\\anoherfolder\\file":   "",
+			"/C:\\anoherfolder/file":   "",
+			"foo/bar/../../file":       "C:\\folder\\file",
+			"foo/bar\\\\\\..\\../file": "C:\\folder\\file",
+			"c:/Folder/fiLe":           "c:\\Folder\\fiLe",
 		},
-		slashdir: {
-			file:           false,
-			slashfile:      false,
-			relfile:        false,
-			shortfile:      true,
-			slashshortfile: true,
+		"/C:/folder": {
+			"C:/folder/file":         "C:\\folder\\file",
+			"/C:/folder/file":        "C:\\folder\\file",
+			"/folder/file":           "C:\\folder\\folder\\file",
+			"file":                   "C:\\folder\\file",
+			"/file":                  "C:\\folder\\file",
+			"C:/anoherfolder/file":   "",
+			"C:\\anoherfolder/file":  "",
+			"/C:\\anoherfolder/file": "",
 		},
-		dirslash: {
-			file:           false,
-			slashfile:      false,
-			relfile:        false,
-			shortfile:      true,
-			slashshortfile: true,
+		"C:/folder/": {
+			"C:/folder/file":         "C:\\folder\\file",
+			"/C:/folder/file":        "C:\\folder\\file",
+			"/folder/file":           "C:\\folder\\folder\\file",
+			"file":                   "C:\\folder\\file",
+			"/file":                  "C:\\folder\\file",
+			"C:/anoherfolder/file":   "",
+			"C:\\anoherfolder/file":  "",
+			"/C:\\anoherfolder/file": "",
 		},
 	}
 
 	for mount, expectations := range tests {
-		fs := OS(mount)
+		fs := osFS(mount)
 		for path, expected := range expectations {
-			stat, err := fs.Stat(nil, path)
-			actual := err == nil
-			if expected != actual {
-				var expectation string
-				if actual {
-					expectation = "not fail"
-				} else {
-					expectation = "fail"
-				}
-				t.Errorf("stat `%s` on `%s` expected to %s", path, mount, expectation)
-				continue
+			actual, _ := fs.resolve(path)
+			if actual != expected {
+				t.Errorf("expected `%s`, got `%s` while resolving `%s` on `%s`", expected, actual, path, mount)
 			}
-			if actual && !os.SameFile(fStat, stat) {
-				t.Errorf("stat `%s` on `%s` points to wrong file", path, mount)
-			}
-
 		}
 	}
 }

--- a/os_windows_test.go
+++ b/os_windows_test.go
@@ -1,0 +1,120 @@
+// +build windows
+
+package ctxvfs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsMount(t *testing.T) {
+
+	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := filepath.Join(tmpDir, "foo")
+	if err = ioutil.WriteFile(tmpFile, []byte("bar"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fStat, _ := os.Stat(tmpFile)
+
+	tmpFile = filepath.ToSlash(tmpFile)
+	tmpDir = filepath.ToSlash(tmpDir)
+
+	volname := filepath.VolumeName(tmpFile)
+
+	var (
+		empty       = ""           // - empty root, OS("")
+		volume      = volname      // - volume name, OS("C:")
+		slashvolume = "/" + volume // - volume name prefixed with slash, OS("/C:")
+		dir         = tmpDir       // - directory, OS("C:/foo/bar")
+		dirslash    = tmpDir + "/" // - directory followed by slash, OS("C:/foo/bar/")
+		slashdir    = "/" + tmpDir // - directory prefixed with slash, OS("/C:/foo/bar")
+	)
+
+	var (
+		file           = tmpFile                             // absolute file path, C:/foo/bar
+		slashfile      = "/" + tmpFile                       // absolute file path prefixed with slash, /C:/foo/bar
+		relfile        = strings.TrimPrefix(tmpFile, volume) // path w/o volume name, /foo/bar
+		shortfile      = "foo"                               // relative path, foo
+		slashshortfile = "/foo"                              // relative path prefixed with slash, /foo
+	)
+
+	// keys are mount points,
+	// values indicate if OS.Stat(path) should succeed for a given path
+	tests := map[string]map[string]bool{
+		empty: {
+			file:           true,
+			slashfile:      true,
+			relfile:        false,
+			shortfile:      false,
+			slashshortfile: false,
+		},
+		volume: {
+			file:           false,
+			slashfile:      false,
+			relfile:        true,
+			shortfile:      false,
+			slashshortfile: false,
+		},
+		slashvolume: {
+			file:           false,
+			slashfile:      false,
+			relfile:        true,
+			shortfile:      false,
+			slashshortfile: false,
+		},
+		dir: {
+			file:           false,
+			slashfile:      false,
+			relfile:        false,
+			shortfile:      true,
+			slashshortfile: true,
+		},
+		slashdir: {
+			file:           false,
+			slashfile:      false,
+			relfile:        false,
+			shortfile:      true,
+			slashshortfile: true,
+		},
+		dirslash: {
+			file:           false,
+			slashfile:      false,
+			relfile:        false,
+			shortfile:      true,
+			slashshortfile: true,
+		},
+	}
+
+	for mount, expectations := range tests {
+		fs := OS(mount)
+		for path, expected := range expectations {
+			stat, err := fs.Stat(nil, path)
+			actual := err == nil
+			if expected != actual {
+				var expectation string
+				if actual {
+					expectation = "not fail"
+				} else {
+					expectation = "fail"
+				}
+				t.Errorf("stat `%s` on `%s` expected to %s", path, mount, expectation)
+				continue
+			}
+			if actual && !os.SameFile(fStat, stat) {
+				t.Errorf("stat `%s` on `%s` points to wrong file", path, mount)
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
This is how I see #3  :smile: 

- we do this so on Windows we can have a VFS which allows access to /C:/foo, /D:/foo, etc
- added test case meant to be run on Windows
- bonus: ability to run Travis CI builds on forked repository
- bonus: Appveyor integration