### PR TITLE
Remove use of ioutil package

### DIFF
--- a/ctxvfs.go
+++ b/ctxvfs.go
@@ -6,7 +6,6 @@ package ctxvfs
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -34,5 +33,5 @@ func ReadFile(ctx context.Context, fs FileSystem, path string) ([]byte, error) {
 		return nil, err
 	}
 	defer rc.Close()
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }

--- a/map_test.go
+++ b/map_test.go
@@ -6,7 +6,6 @@ package ctxvfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -37,7 +36,7 @@ func TestMap_openRoot(t *testing.T) {
 			t.Errorf("Open(%q) = %v", tt.path, err)
 			continue
 		}
-		slurp, err := ioutil.ReadAll(rsc)
+		slurp, err := io.ReadAll(rsc)
 		if err != nil {
 			t.Error(err)
 		}

--- a/os.go
+++ b/os.go
@@ -7,7 +7,6 @@ package ctxvfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -69,5 +68,5 @@ func (root osFS) ReadDir(ctx context.Context, path string) ([]os.FileInfo, error
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadDir(resolved) // is sorted
+	return os.ReadDir(resolved) // is sorted
 }

--- a/os_test.go
+++ b/os_test.go
@@ -5,16 +5,15 @@
 package ctxvfs
 
 import (
-	"io/ioutil"
-	"strings"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestOpenLocal(t *testing.T) {
 
-	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	tmpDir, err := os.MkdirTemp("", "vfs-localfs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +22,7 @@ func TestOpenLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 	file := filepath.Join(tmpDir, "foo")
-	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+	if err = os.WriteFile(file, []byte("bar"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -64,7 +63,7 @@ func TestOpenLocal(t *testing.T) {
 
 func TestOpenOverlay(t *testing.T) {
 
-	tmpDir, err := ioutil.TempDir("", "vfs-localfs")
+	tmpDir, err := os.MkdirTemp("", "vfs-localfs")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +72,7 @@ func TestOpenOverlay(t *testing.T) {
 		t.Fatal(err)
 	}
 	file := filepath.Join(tmpDir, "foo")
-	if err = ioutil.WriteFile(file, []byte("bar"), 0600); err != nil {
+	if err = os.WriteFile(file, []byte("bar"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +88,7 @@ func TestOpenOverlay(t *testing.T) {
 	if err != nil {
 		t.Errorf("Cannot read overlayed file (%s)", err)
 	}
-	content, err := ioutil.ReadAll(stream)
+	content, err := io.ReadAll(stream)
 	if err != nil {
 		t.Errorf("Cannot read overlayed file (%s)", err)
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)